### PR TITLE
Downgrade reviews-api Boot version to be in line with bottles and users APIs

### DIFF
--- a/reviews-api/pom.xml
+++ b/reviews-api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.1.0</version>
+		<version>3.5.15</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.bourbon_nook</groupId>
@@ -28,7 +28,7 @@
 	</scm>
 	<properties>
 		<java.version>17</java.version>
-		<spring-cloud.version>2025.1.2</spring-cloud.version>
+		<spring-cloud.version>2025.0.3</spring-cloud.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/reviews-api/src/main/java/com/bourbon_nook/reviews_api/config/RabbitConfig.java
+++ b/reviews-api/src/main/java/com/bourbon_nook/reviews_api/config/RabbitConfig.java
@@ -4,7 +4,7 @@ import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.FanoutExchange;
 import org.springframework.amqp.core.Queue;
-import org.springframework.amqp.support.converter.JacksonJsonMessageConverter;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -30,6 +30,6 @@ public class RabbitConfig {
 
     @Bean
     public MessageConverter jsonMessageConverter() {
-        return new JacksonJsonMessageConverter();
+        return new Jackson2JsonMessageConverter();
     }
 }

--- a/reviews-api/src/main/java/com/bourbon_nook/reviews_api/utils/RestAuthenticationEntryPoint.java
+++ b/reviews-api/src/main/java/com/bourbon_nook/reviews_api/utils/RestAuthenticationEntryPoint.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
-import tools.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;


### PR DESCRIPTION
## Downgrade `reviews-api` to Boot version used in `bottles-api`, `users-api`, etc.

### What did you do
- Downgraded Boot version in `reviews-api`
- Replaced `JacksonJsonMessageConverter` with `Jackson2JsonMessageConverter` per downgrade
- Replaced `tools.jackson.databind.ObjectMapper` with `com.fasterxml.jackson.databind.ObjectMapper` per downgrade