### PR TITLE
chore: add username and email availability checks on RegisterForm

### DIFF
--- a/frontend/src/api/generated/users-api.ts
+++ b/frontend/src/api/generated/users-api.ts
@@ -42,13 +42,13 @@ export interface UserResponseModel {
 export interface CreateUserRequest {
   email: string;
   /**
-     * @minLength 2
+     * @minLength 3
      * @maxLength 2147483647
      */
   username: string;
   /**
      * @minLength 8
-     * @maxLength 20
+     * @maxLength 2147483647
      */
   password: string;
 }
@@ -75,6 +75,14 @@ export interface ChangePasswordRequest {
 export interface DeleteAccountRequest {
   password: string;
 }
+
+export type CheckUsernameAvailabilityParams = {
+username: string;
+};
+
+export type CheckEmailAvailabilityParams = {
+email: string;
+};
 
 const withQueryKey = <T extends object, K>(query: T, queryKey: K): T & { queryKey: K } => {
   const result = { queryKey } as T & { queryKey: K };
@@ -1113,3 +1121,277 @@ const {mutation: mutationOptions} = options ?
       > => {
       return useMutation(getDeleteAccountMutationOptions(options), queryClient);
     }
+
+export const checkUsernameAvailability = (
+    params: CheckUsernameAvailabilityParams,
+ signal?: AbortSignal
+) => {
+
+
+      return customUsersInstance<boolean>(
+      {url: `/auth/check-username`, method: 'GET',
+        params, signal
+    },
+      );
+    }
+
+
+
+
+export const getCheckUsernameAvailabilityQueryKey = (params?: CheckUsernameAvailabilityParams,) => {
+    return [
+    `/auth/check-username`, ...(params ? [params] : [])
+    ] as const;
+    }
+
+
+export const getCheckUsernameAvailabilityQueryOptions = <TData = Awaited<ReturnType<typeof checkUsernameAvailability>>, TError = unknown>(params: CheckUsernameAvailabilityParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof checkUsernameAvailability>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getCheckUsernameAvailabilityQueryKey(params);
+
+
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof checkUsernameAvailability>>> = ({ signal }) => checkUsernameAvailability(params, signal);
+
+
+
+
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof checkUsernameAvailability>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type CheckUsernameAvailabilityQueryResult = NonNullable<Awaited<ReturnType<typeof checkUsernameAvailability>>>
+export type CheckUsernameAvailabilityQueryError = unknown
+
+
+export function useCheckUsernameAvailability<TData = Awaited<ReturnType<typeof checkUsernameAvailability>>, TError = unknown>(
+ params: CheckUsernameAvailabilityParams, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof checkUsernameAvailability>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof checkUsernameAvailability>>,
+          TError,
+          Awaited<ReturnType<typeof checkUsernameAvailability>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useCheckUsernameAvailability<TData = Awaited<ReturnType<typeof checkUsernameAvailability>>, TError = unknown>(
+ params: CheckUsernameAvailabilityParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof checkUsernameAvailability>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof checkUsernameAvailability>>,
+          TError,
+          Awaited<ReturnType<typeof checkUsernameAvailability>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useCheckUsernameAvailability<TData = Awaited<ReturnType<typeof checkUsernameAvailability>>, TError = unknown>(
+ params: CheckUsernameAvailabilityParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof checkUsernameAvailability>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+
+export function useCheckUsernameAvailability<TData = Awaited<ReturnType<typeof checkUsernameAvailability>>, TError = unknown>(
+ params: CheckUsernameAvailabilityParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof checkUsernameAvailability>>, TError, TData>>, }
+ , queryClient?: QueryClient
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getCheckUsernameAvailabilityQueryOptions(params,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  return withQueryKey(query, queryOptions.queryKey);
+}
+
+
+
+
+
+
+export const getCheckUsernameAvailabilitySuspenseQueryOptions = <TData = Awaited<ReturnType<typeof checkUsernameAvailability>>, TError = unknown>(params: CheckUsernameAvailabilityParams, options?: { query?:Partial<UseSuspenseQueryOptions<Awaited<ReturnType<typeof checkUsernameAvailability>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getCheckUsernameAvailabilityQueryKey(params);
+
+
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof checkUsernameAvailability>>> = ({ signal }) => checkUsernameAvailability(params, signal);
+
+
+
+
+
+   return  { queryKey, queryFn, ...queryOptions} as UseSuspenseQueryOptions<Awaited<ReturnType<typeof checkUsernameAvailability>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type CheckUsernameAvailabilitySuspenseQueryResult = NonNullable<Awaited<ReturnType<typeof checkUsernameAvailability>>>
+export type CheckUsernameAvailabilitySuspenseQueryError = unknown
+
+
+export function useCheckUsernameAvailabilitySuspense<TData = Awaited<ReturnType<typeof checkUsernameAvailability>>, TError = unknown>(
+ params: CheckUsernameAvailabilityParams, options: { query:Partial<UseSuspenseQueryOptions<Awaited<ReturnType<typeof checkUsernameAvailability>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseSuspenseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useCheckUsernameAvailabilitySuspense<TData = Awaited<ReturnType<typeof checkUsernameAvailability>>, TError = unknown>(
+ params: CheckUsernameAvailabilityParams, options?: { query?:Partial<UseSuspenseQueryOptions<Awaited<ReturnType<typeof checkUsernameAvailability>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseSuspenseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useCheckUsernameAvailabilitySuspense<TData = Awaited<ReturnType<typeof checkUsernameAvailability>>, TError = unknown>(
+ params: CheckUsernameAvailabilityParams, options?: { query?:Partial<UseSuspenseQueryOptions<Awaited<ReturnType<typeof checkUsernameAvailability>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseSuspenseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+
+export function useCheckUsernameAvailabilitySuspense<TData = Awaited<ReturnType<typeof checkUsernameAvailability>>, TError = unknown>(
+ params: CheckUsernameAvailabilityParams, options?: { query?:Partial<UseSuspenseQueryOptions<Awaited<ReturnType<typeof checkUsernameAvailability>>, TError, TData>>, }
+ , queryClient?: QueryClient
+ ):  UseSuspenseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getCheckUsernameAvailabilitySuspenseQueryOptions(params,options)
+
+  const query = useSuspenseQuery(queryOptions, queryClient) as  UseSuspenseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  return withQueryKey(query, queryOptions.queryKey);
+}
+
+
+
+
+
+
+
+export const checkEmailAvailability = (
+    params: CheckEmailAvailabilityParams,
+ signal?: AbortSignal
+) => {
+
+
+      return customUsersInstance<boolean>(
+      {url: `/auth/check-email`, method: 'GET',
+        params, signal
+    },
+      );
+    }
+
+
+
+
+export const getCheckEmailAvailabilityQueryKey = (params?: CheckEmailAvailabilityParams,) => {
+    return [
+    `/auth/check-email`, ...(params ? [params] : [])
+    ] as const;
+    }
+
+
+export const getCheckEmailAvailabilityQueryOptions = <TData = Awaited<ReturnType<typeof checkEmailAvailability>>, TError = unknown>(params: CheckEmailAvailabilityParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof checkEmailAvailability>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getCheckEmailAvailabilityQueryKey(params);
+
+
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof checkEmailAvailability>>> = ({ signal }) => checkEmailAvailability(params, signal);
+
+
+
+
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof checkEmailAvailability>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type CheckEmailAvailabilityQueryResult = NonNullable<Awaited<ReturnType<typeof checkEmailAvailability>>>
+export type CheckEmailAvailabilityQueryError = unknown
+
+
+export function useCheckEmailAvailability<TData = Awaited<ReturnType<typeof checkEmailAvailability>>, TError = unknown>(
+ params: CheckEmailAvailabilityParams, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof checkEmailAvailability>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof checkEmailAvailability>>,
+          TError,
+          Awaited<ReturnType<typeof checkEmailAvailability>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useCheckEmailAvailability<TData = Awaited<ReturnType<typeof checkEmailAvailability>>, TError = unknown>(
+ params: CheckEmailAvailabilityParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof checkEmailAvailability>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof checkEmailAvailability>>,
+          TError,
+          Awaited<ReturnType<typeof checkEmailAvailability>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useCheckEmailAvailability<TData = Awaited<ReturnType<typeof checkEmailAvailability>>, TError = unknown>(
+ params: CheckEmailAvailabilityParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof checkEmailAvailability>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+
+export function useCheckEmailAvailability<TData = Awaited<ReturnType<typeof checkEmailAvailability>>, TError = unknown>(
+ params: CheckEmailAvailabilityParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof checkEmailAvailability>>, TError, TData>>, }
+ , queryClient?: QueryClient
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getCheckEmailAvailabilityQueryOptions(params,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  return withQueryKey(query, queryOptions.queryKey);
+}
+
+
+
+
+
+
+export const getCheckEmailAvailabilitySuspenseQueryOptions = <TData = Awaited<ReturnType<typeof checkEmailAvailability>>, TError = unknown>(params: CheckEmailAvailabilityParams, options?: { query?:Partial<UseSuspenseQueryOptions<Awaited<ReturnType<typeof checkEmailAvailability>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getCheckEmailAvailabilityQueryKey(params);
+
+
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof checkEmailAvailability>>> = ({ signal }) => checkEmailAvailability(params, signal);
+
+
+
+
+
+   return  { queryKey, queryFn, ...queryOptions} as UseSuspenseQueryOptions<Awaited<ReturnType<typeof checkEmailAvailability>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type CheckEmailAvailabilitySuspenseQueryResult = NonNullable<Awaited<ReturnType<typeof checkEmailAvailability>>>
+export type CheckEmailAvailabilitySuspenseQueryError = unknown
+
+
+export function useCheckEmailAvailabilitySuspense<TData = Awaited<ReturnType<typeof checkEmailAvailability>>, TError = unknown>(
+ params: CheckEmailAvailabilityParams, options: { query:Partial<UseSuspenseQueryOptions<Awaited<ReturnType<typeof checkEmailAvailability>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseSuspenseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useCheckEmailAvailabilitySuspense<TData = Awaited<ReturnType<typeof checkEmailAvailability>>, TError = unknown>(
+ params: CheckEmailAvailabilityParams, options?: { query?:Partial<UseSuspenseQueryOptions<Awaited<ReturnType<typeof checkEmailAvailability>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseSuspenseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useCheckEmailAvailabilitySuspense<TData = Awaited<ReturnType<typeof checkEmailAvailability>>, TError = unknown>(
+ params: CheckEmailAvailabilityParams, options?: { query?:Partial<UseSuspenseQueryOptions<Awaited<ReturnType<typeof checkEmailAvailability>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseSuspenseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+
+export function useCheckEmailAvailabilitySuspense<TData = Awaited<ReturnType<typeof checkEmailAvailability>>, TError = unknown>(
+ params: CheckEmailAvailabilityParams, options?: { query?:Partial<UseSuspenseQueryOptions<Awaited<ReturnType<typeof checkEmailAvailability>>, TError, TData>>, }
+ , queryClient?: QueryClient
+ ):  UseSuspenseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getCheckEmailAvailabilitySuspenseQueryOptions(params,options)
+
+  const query = useSuspenseQuery(queryOptions, queryClient) as  UseSuspenseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  return withQueryKey(query, queryOptions.queryKey);
+}

--- a/frontend/src/components/Forms/RegisterForm.tsx
+++ b/frontend/src/components/Forms/RegisterForm.tsx
@@ -2,13 +2,17 @@ import { z } from 'zod';
 import { useAppForm } from '../../hooks/form';
 import type { AuthState } from '../../auth/types';
 import { Link, useNavigate } from '@tanstack/react-router';
+import {
+  checkEmailAvailability,
+  checkUsernameAvailability,
+} from '../../api/generated/users-api';
 
 const registerSchema = z.object({
   email: z.email('Please enter a valid email address'),
   username: z
     .string()
     .min(3, 'Username must be at least 3 characters')
-    .regex(/[^a-zA-Z0-9\s]/, 'Username cannot contain special characters'),
+    .regex(/^[A-Za-z0-9]+$/, 'Username cannot contain special characters'),
   password: z.string().min(8, 'Password must be at least 8 characters'),
   confirmPassword: z.string().min(8, 'Password must be at least 8 characters'),
 });
@@ -61,11 +65,22 @@ export default function RegisterForm({ auth, redirect }: RegisterFormProps) {
         <div>
           <form.AppField
             name="email"
+            validators={{
+              onChangeAsyncDebounceMs: 500,
+              onChangeAsync: async ({ value }) => {
+                const isAvailable = await checkEmailAvailability({
+                  email: value,
+                });
+                return isAvailable
+                  ? undefined
+                  : 'Email is already registered at BourbonNook';
+              },
+            }}
             children={(field) => (
               <field.TextField
                 label="Email"
                 type="email"
-                placeholder="john@hopkins.edu"
+                placeholder="john@whiskey.org"
                 required
               />
             )}
@@ -74,6 +89,16 @@ export default function RegisterForm({ auth, redirect }: RegisterFormProps) {
         <div>
           <form.AppField
             name="username"
+            validators={{
+              onChangeAsyncDebounceMs: 500,
+              onChangeAsync: async ({ value }) => {
+                if (value.length < 3) return undefined;
+                const isAvailable = await checkUsernameAvailability({
+                  username: value,
+                });
+                return isAvailable ? undefined : 'Username is already taken';
+              },
+            }}
             children={(field) => (
               <field.TextField
                 label="Username"

--- a/frontend/src/components/Inputs/TextField.tsx
+++ b/frontend/src/components/Inputs/TextField.tsx
@@ -22,6 +22,7 @@ export default function TextField({
   const errorId = `${id}-error`;
   const hasError =
     field.state.meta.isTouched && field.state.meta.errors.length > 0;
+  const isValidating = field.state.meta.isValidating;
 
   return (
     <div className="flex w-full flex-col gap-1.5">
@@ -52,6 +53,9 @@ export default function TextField({
           hasError ? 'border-red-500/70' : 'border-amber-900/40'
         }`}
       />
+      {isValidating && !hasError && (
+        <p className="text-sm text-amber-100/60">Checking…</p>
+      )}
       {hasError && (
         <p id={errorId} role="alert" className="text-sm text-red-400">
           {formatFieldErrors(field.state.meta.errors)}

--- a/users-api/src/main/java/com/bourbon_nook/users_api/controllers/AuthController.java
+++ b/users-api/src/main/java/com/bourbon_nook/users_api/controllers/AuthController.java
@@ -113,6 +113,16 @@ public class AuthController {
                 .body(userResponseModel);
     }
 
+    @GetMapping("/check-username")
+    public ResponseEntity<Boolean> checkUsernameAvailability(@RequestParam String username) {
+        return ResponseEntity.ok(userService.isUsernameAvailable(username));
+    }
+
+    @GetMapping("/check-email")
+    public ResponseEntity<Boolean> checkEmailAvailability(@RequestParam String email) {
+        return ResponseEntity.ok(userService.isEmailAvailable(email));
+    }
+
     @PostMapping("/register")
     public ResponseEntity<UserResponseModel> register(@RequestBody CreateUserRequest createUserRequest) {
         UserDto userDto = modelMapper.map(createUserRequest, UserDto.class);

--- a/users-api/src/main/java/com/bourbon_nook/users_api/security/WebSecurity.java
+++ b/users-api/src/main/java/com/bourbon_nook/users_api/security/WebSecurity.java
@@ -51,7 +51,7 @@ public class WebSecurity {
         http.authorizeHttpRequests(auth ->
                         auth
                                 .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
-                                .requestMatchers("/auth/login", "/auth/register", "/auth/logout", "/auth/refresh").permitAll()
+                                .requestMatchers("/auth/login", "/auth/register", "/auth/logout", "/auth/refresh", "/auth/check-username", "/auth/check-email").permitAll()
                                 .requestMatchers("/auth/me", "/auth/change-password").access(new WebExpressionAuthorizationManager(gatewayIpExpression + " and isAuthenticated()"))
                                 .requestMatchers("/users/**").access(new WebExpressionAuthorizationManager(gatewayIpExpression + " and hasRole('ADMIN')"))
                                 .requestMatchers(HttpMethod.GET, "/actuator/**").access(new WebExpressionAuthorizationManager(gatewayIpExpression + " and hasRole('ADMIN')"))

--- a/users-api/src/main/java/com/bourbon_nook/users_api/services/RefreshTokenServiceImpl.java
+++ b/users-api/src/main/java/com/bourbon_nook/users_api/services/RefreshTokenServiceImpl.java
@@ -3,6 +3,7 @@ package com.bourbon_nook.users_api.services;
 import com.bourbon_nook.users_api.entities.RefreshTokenEntity;
 import com.bourbon_nook.users_api.repositories.RefreshTokenRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -45,6 +46,7 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
                 });
     }
 
+    @Transactional
     @Override
     public void revokeAllForUser(String userId) {
         refreshTokenRepository.revokeAllForUser(userId);

--- a/users-api/src/main/java/com/bourbon_nook/users_api/services/UserService.java
+++ b/users-api/src/main/java/com/bourbon_nook/users_api/services/UserService.java
@@ -13,4 +13,6 @@ public interface UserService extends UserDetailsService {
     UserDto createUser(UserDto userDetails, String rawPassword);
     UserDto updateUser(String userId, UpdateUserRequest userDetails);
     void deleteUser(String userId);
+    boolean isUsernameAvailable(String username);
+    boolean isEmailAvailable(String email);
 }

--- a/users-api/src/main/java/com/bourbon_nook/users_api/services/UserServiceImpl.java
+++ b/users-api/src/main/java/com/bourbon_nook/users_api/services/UserServiceImpl.java
@@ -110,6 +110,16 @@ public class UserServiceImpl implements UserService {
         rabbitTemplate.convertAndSend(RabbitConfig.USER_DELETE_EXCHANGE, "", new UserDeletedEvent(userId));
     }
 
+    @Override
+    public boolean isUsernameAvailable(String username) {
+        return !userRepository.existsByUsername(username);
+    }
+
+    @Override
+    public boolean isEmailAvailable(String email) {
+        return !userRepository.existsByEmail(email);
+    }
+
     private RoleEntity getOrCreateRole(RoleType roleType) {
         return roleRepository.findByName(roleType)
                 .orElseGet(() -> roleRepository.save(new RoleEntity(roleType)));


### PR DESCRIPTION
## Add email/username checks on registration

### What did you do
- Added scaffolding for username and email availability checks in `users-api`
- Added async validators to `RegisterForm` to check for username/email availability
- Regenerated API queries based on new endpoints/contracts