### PR TITLE
chore: add tests to bottle routes

### DIFF
--- a/bottles-api/src/main/java/com/bourbon_nook/bottles_api/controllers/BottleController.java
+++ b/bottles-api/src/main/java/com/bourbon_nook/bottles_api/controllers/BottleController.java
@@ -8,6 +8,7 @@ import com.bourbon_nook.bottles_api.models.responses.BottleResponseModel;
 import com.bourbon_nook.bottles_api.models.responses.ImageResponseModel;
 import com.bourbon_nook.bottles_api.services.BottleService;
 
+import jakarta.validation.Valid;
 import org.modelmapper.ModelMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,7 +54,7 @@ public class BottleController {
         List<BottleResponseModel> returnValue = new ArrayList<>();
 
         if(bottles == null || bottles.isEmpty()) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(returnValue);
+            return ResponseEntity.status(HttpStatus.OK).body(returnValue);
         }
 
         for (BottleDto bottle : bottles) {
@@ -111,7 +112,7 @@ public class BottleController {
 
     @PreAuthorize("isAuthenticated()")
     @PostMapping("/new")
-    public ResponseEntity<BottleResponseModel> bottleCreate(@RequestBody CreateBottleRequest createBottleRequest,
+    public ResponseEntity<BottleResponseModel> bottleCreate(@Valid @RequestBody CreateBottleRequest createBottleRequest,
                                                             Authentication authentication
     ) {
         String userId = authentication.getName();
@@ -136,7 +137,7 @@ public class BottleController {
     @PreAuthorize("isAuthenticated()")
     @PutMapping("/{bottleId}")
     public ResponseEntity<BottleResponseModel> bottleUpdate(@PathVariable String bottleId,
-                                                            @RequestBody CreateBottleRequest createBottleRequest,
+                                                            @Valid @RequestBody CreateBottleRequest createBottleRequest,
                                                             Authentication authentication
     ) {
         String userId = authentication.getName();

--- a/bottles-api/src/main/java/com/bourbon_nook/bottles_api/models/requests/CreateBottleRequest.java
+++ b/bottles-api/src/main/java/com/bourbon_nook/bottles_api/models/requests/CreateBottleRequest.java
@@ -16,37 +16,26 @@ public class CreateBottleRequest {
     @NotNull(message = "Status is required")
     private BottleStatus status;
 
-    @NotNull(message = "Distillery is required")
     private String distillery;
 
-    @NotNull(message = "Producer is required")
     private String producer;
 
-    @NotNull(message = "Country is required")
     private String country;
 
-    @NotNull(message = "Region is required")
     private String region;
 
-    @NotNull(message = "Price is required")
     private BigDecimal price;
 
-    @NotNull(message = "Age is required")
     private String age;
 
-    @NotNull(message = "Proof is required")
     private double proof;
 
-    @NotNull(message = "Release year is required")
     private int releaseYear;
 
-    @NotNull(message = "Barrel information is required. Type 'N/A' if no additional information is given")
     private String barrelInformation;
 
-    @NotNull(message = "Finishing is required. Type 'N/A' if no finishing barrels were used")
     private String finishing;
 
-    @NotNull(message = "Image URL is required")
     private String imageUrl;
 
     private LocalDate openDate;

--- a/bottles-api/src/main/java/com/bourbon_nook/bottles_api/services/BottleServiceImpl.java
+++ b/bottles-api/src/main/java/com/bourbon_nook/bottles_api/services/BottleServiceImpl.java
@@ -4,6 +4,7 @@ import com.bourbon_nook.bottles_api.dtos.BottleDto;
 import com.bourbon_nook.bottles_api.dtos.ImageDto;
 import com.bourbon_nook.bottles_api.entities.BottleEntity;
 import com.bourbon_nook.bottles_api.exceptions.BottleNotFoundException;
+import com.bourbon_nook.bottles_api.exceptions.DatabaseErrorException;
 import com.bourbon_nook.bottles_api.exceptions.ImageUploadException;
 import com.bourbon_nook.bottles_api.mappers.BottleMapper;
 import com.bourbon_nook.bottles_api.repositories.BottleRepository;
@@ -66,10 +67,14 @@ public class BottleServiceImpl implements BottleService {
 
     @Override
     public BottleDto createBottle(String userId, BottleDto bottleDto) {
-        BottleEntity bottle = bottleMapper.toEntity(bottleDto);
-        bottle.setUserId(userId);
-        BottleEntity savedBottle = bottleRepository.save(bottle);
-        return bottleMapper.toDto(savedBottle);
+        try {
+            BottleEntity bottle = bottleMapper.toEntity(bottleDto);
+            bottle.setUserId(userId);
+            BottleEntity savedBottle = bottleRepository.save(bottle);
+            return bottleMapper.toDto(savedBottle);
+        } catch(DatabaseErrorException e) {
+            throw new DatabaseErrorException("Could not save bottle: " + e.getMessage());
+        }
     }
 
     @Override

--- a/frontend/src/components/Forms/BottleForm.tsx
+++ b/frontend/src/components/Forms/BottleForm.tsx
@@ -55,7 +55,6 @@ export default function BottleForm({
                 label="Bottle Name"
                 type="text"
                 placeholder="Buffalo Trace"
-                required
               />
             )}
           />
@@ -67,7 +66,6 @@ export default function BottleForm({
                   label="Liquor Type"
                   type="text"
                   placeholder="Bourbon"
-                  required
                 />
               )}
             />
@@ -81,7 +79,6 @@ export default function BottleForm({
                     { value: 'OPENED', label: 'Opened' },
                     { value: 'FINISHED', label: 'Finished' },
                   ]}
-                  required
                 />
               )}
             />
@@ -100,7 +97,6 @@ export default function BottleForm({
                   label="Distillery"
                   type="text"
                   placeholder="Buffalo Trace, Heaven Hill"
-                  required
                 />
               )}
             />
@@ -111,7 +107,6 @@ export default function BottleForm({
                   label="Producer"
                   type="text"
                   placeholder="Sazerac, MGP"
-                  required
                 />
               )}
             />
@@ -122,7 +117,6 @@ export default function BottleForm({
                   label="Country of Origin"
                   type="text"
                   placeholder="USA, Japan, Scotland"
-                  required
                 />
               )}
             />
@@ -133,7 +127,6 @@ export default function BottleForm({
                   label="Region"
                   type="text"
                   placeholder="KY, Islay, Hokkaido"
-                  required
                 />
               )}
             />
@@ -147,7 +140,7 @@ export default function BottleForm({
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <form.AppField
               name="price"
-              children={(field) => <field.NumberField label="Price" required />}
+              children={(field) => <field.NumberField label="Price" />}
             />
             <form.AppField
               name="age"
@@ -156,19 +149,16 @@ export default function BottleForm({
                   label="Age"
                   type="text"
                   placeholder="10yrs, 6yrs 7mos, NAS"
-                  required
                 />
               )}
             />
             <form.AppField
               name="proof"
-              children={(field) => <field.NumberField label="Proof" required />}
+              children={(field) => <field.NumberField label="Proof" />}
             />
             <form.AppField
               name="releaseYear"
-              children={(field) => (
-                <field.NumberField label="Release Year" required />
-              )}
+              children={(field) => <field.NumberField label="Release Year" />}
             />
           </div>
         </div>
@@ -185,7 +175,6 @@ export default function BottleForm({
                   label="Barrel Information"
                   type="text"
                   placeholder="Binny's Pick, Barrel A225G3"
-                  required
                 />
               )}
             />
@@ -196,7 +185,6 @@ export default function BottleForm({
                   label="Finishing Barrels"
                   type="text"
                   placeholder="Port, Sauternes, Tequila"
-                  required
                 />
               )}
             />
@@ -205,15 +193,8 @@ export default function BottleForm({
 
         <div className="space-y-4 border-t border-ink/10 pt-6">
           <h2 className="text-xs font-semibold uppercase tracking-wide text-ink/50">
-            Extras
+            Timeline
           </h2>
-          {/* Will need to change */}
-          <form.AppField
-            name="imageUrl"
-            children={(field) => (
-              <field.TextField label="Image URL" type="text" />
-            )}
-          />
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <form.AppField
               name="openDate"
@@ -225,7 +206,6 @@ export default function BottleForm({
             />
           </div>
         </div>
-
         <form.AppForm>
           <form.SubmitButton label="Save Bottle" fullWidth />
         </form.AppForm>

--- a/frontend/src/components/ui/ActionButtons.tsx
+++ b/frontend/src/components/ui/ActionButtons.tsx
@@ -43,31 +43,27 @@ export default function ActionButtons({
       className={showLabels ? 'flex flex-wrap gap-3' : 'flex justify-around'}
     >
       <div>
-        <button type="button">
-          <Link
-            to="/reviews/new"
-            title="Write Review"
-            aria-label="Add Review"
-            className={showLabels ? labeledButtonClasses : undefined}
-          >
-            <PlusIcon />
-            {showLabels && 'Write Review'}
-          </Link>
-        </button>
+        <Link
+          to="/reviews/new"
+          title="Write Review"
+          aria-label="Write Review"
+          className={showLabels ? labeledButtonClasses : undefined}
+        >
+          <PlusIcon />
+          {showLabels && 'Write Review'}
+        </Link>
       </div>
       <div>
-        <button type="button">
-          <Link
-            to="/bottles/$bottleId/edit"
-            params={{ bottleId }}
-            title="Edit Bottle"
-            aria-label="Edit Bottle"
-            className={showLabels ? labeledButtonClasses : undefined}
-          >
-            <EditIcon />
-            {showLabels && 'Edit Bottle'}
-          </Link>
-        </button>
+        <Link
+          to="/bottles/$bottleId/edit"
+          params={{ bottleId }}
+          title="Edit Bottle"
+          aria-label="Edit Bottle"
+          className={showLabels ? labeledButtonClasses : undefined}
+        >
+          <EditIcon />
+          {showLabels && 'Edit Bottle'}
+        </Link>
       </div>
       <div>
         <button

--- a/frontend/src/components/ui/ConfirmDialog.tsx
+++ b/frontend/src/components/ui/ConfirmDialog.tsx
@@ -55,7 +55,9 @@ export default function ConfirmDialog({
           {title}
         </h2>
         {description && (
-          <p className="mt-2 text-sm text-ink/70">{description}</p>
+          <p className="mt-2 text-sm text-ink/70" role="alert">
+            {description}
+          </p>
         )}
         <div className="mt-6 flex justify-end gap-3">
           <button

--- a/frontend/src/hooks/useBottleForm.tsx
+++ b/frontend/src/hooks/useBottleForm.tsx
@@ -10,8 +10,8 @@ import { useAppForm } from './form';
 import { getApiErrorMessage } from '../api/errors';
 
 const bottleSchema = z.object({
-  name: z.string('Name is required'),
-  type: z.string('Type is required'),
+  name: z.string().min(1, 'Name is required'),
+  type: z.string().min(1, 'Type is required'),
   status: z.enum(['OPENED', 'SEALED', 'FINISHED'], 'Status is required'),
   distillery: z.string().optional(),
   producer: z.string().optional(),
@@ -23,7 +23,6 @@ const bottleSchema = z.object({
   releaseYear: z.number().optional(),
   barrelInformation: z.string().optional(),
   finishing: z.string().optional(),
-  imageUrl: z.string().optional(),
   openDate: z.iso.date().or(z.literal('')).optional(),
   killDate: z.iso.date().or(z.literal('')).optional(),
   mode: z.enum(['create', 'edit']),
@@ -46,7 +45,6 @@ const defaultValues: Bottle = {
   releaseYear: 0,
   barrelInformation: '',
   finishing: '',
-  imageUrl: '',
   openDate: '',
   killDate: '',
   mode: 'create',
@@ -105,7 +103,7 @@ export default function useBottleForm({
             releaseYear: payload.releaseYear || 0,
             barrelInformation: payload.barrelInformation || '',
             finishing: payload.finishing || '',
-            imageUrl: payload.imageUrl || '',
+            imageUrl: '',
             openDate: payload.openDate,
             killDate: payload.killDate,
           });
@@ -119,6 +117,7 @@ export default function useBottleForm({
       } else if (value.mode === 'edit') {
         if (!bottleId) {
           setServerError("Error! You can't edit an unknown bottle");
+          return;
         }
         try {
           const payload = {
@@ -140,7 +139,7 @@ export default function useBottleForm({
             releaseYear: payload.releaseYear || 0,
             barrelInformation: payload.barrelInformation || '',
             finishing: payload.finishing || '',
-            imageUrl: payload.imageUrl || '',
+            imageUrl: '',
             openDate: payload.openDate,
             killDate: payload.killDate,
           });

--- a/frontend/src/test/file-route-utils.tsx
+++ b/frontend/src/test/file-route-utils.tsx
@@ -4,7 +4,7 @@ import {
   RouterProvider,
   createMemoryHistory,
 } from '@tanstack/react-router';
-import { QueryClient } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { vi } from 'vitest';
 
 import { routeTree } from '../routeTree.gen';
@@ -72,25 +72,29 @@ export function renderWithFileRoutes({
   ...renderOptions
 }: RenderWithFileRoutesOptions = {}) {
   const auth = routerContext.auth ?? createMockAuthState();
+  const queryClient = routerContext.queryClient ?? createTestQueryClient();
   const router = createRouter({
     routeTree,
     history: createMemoryHistory({
       initialEntries: [initialLocation],
     }),
     context: {
-      queryClient: createTestQueryClient(),
       ...routerContext,
+      queryClient,
       auth,
     },
   });
 
   return {
     ...render(
-      <AuthContext.Provider value={auth}>
-        <RouterProvider router={router} />
-      </AuthContext.Provider>,
+      <QueryClientProvider client={queryClient}>
+        <AuthContext.Provider value={auth}>
+          <RouterProvider router={router} />
+        </AuthContext.Provider>
+      </QueryClientProvider>,
       renderOptions,
     ),
+    router,
   };
 }
 

--- a/frontend/src/test/routes/bottles/$bottleId.test.tsx
+++ b/frontend/src/test/routes/bottles/$bottleId.test.tsx
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import {
+  createMockAuthState,
+  renderWithFileRoutes,
+} from '../../file-route-utils';
+import type { BottleResponseModel } from '../../../api/generated/bottles-api';
+import userEvent from '@testing-library/user-event';
+import { customBottlesInstance } from '../../../api/axios-instance';
+
+function returnBottleResponse(): BottleResponseModel {
+  return {
+    id: '12345',
+    name: 'Mock Bottle',
+    type: 'Bourbon',
+    status: 'OPENED',
+    distillery: 'Mock Distillery',
+    producer: 'Mock Producer',
+    country: 'USA',
+    region: 'KY',
+    price: 25.99,
+    age: 'NAS',
+    proof: 115.2,
+    releaseYear: 2026,
+    barrelInformation: 'N/A',
+    finishing: 'N/A',
+    imageUrl:
+      'https://bourbon-nook.s3.amazonaws.com/8d617ebd-1ccd-45e3-876f-13df82cfe8c3/e89ae702-cfbc-475b-8ba4-8c6b3d4cb1f7-wtmk%20beacon.webp',
+    openDate: '2026-07-29',
+    killDate: undefined,
+  };
+}
+
+function renderBottleIdRouteWithAuth() {
+  return renderWithFileRoutes({
+    initialLocation: '/bottles/12345',
+    routerContext: {
+      auth: createMockAuthState({
+        user: {
+          id: '123abc',
+          email: 'test@email.com',
+          username: 'testuser',
+          roles: ['ROLE_USER'],
+        },
+        isAuthenticated: true,
+      }),
+    },
+  });
+}
+
+async function getSelectors() {
+  const pageTitle = await screen.findByText(/mock bottle/i);
+  const status = await screen.findByText(/opened/i);
+  const price = await screen.findByText(/25.99/i);
+  const writeReviewLink = await screen.findByRole('link', {
+    name: /write review/i,
+  });
+  const editBottleLink = await screen.findByRole('link', {
+    name: /edit bottle/i,
+  });
+  const deleteBottleButton = await screen.findByRole('button', {
+    name: /delete bottle/i,
+  });
+  const bottleImage = await screen.findByRole('img');
+
+  return {
+    pageTitle,
+    status,
+    price,
+    writeReviewLink,
+    editBottleLink,
+    deleteBottleButton,
+    bottleImage,
+  };
+}
+
+vi.mock('../../../api/axios-instance', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../api/axios-instance')>();
+
+  const bottleResponse = returnBottleResponse();
+
+  return {
+    ...actual,
+    customBottlesInstance: vi.fn().mockResolvedValue(bottleResponse),
+  };
+});
+
+describe('Bottle ID route', () => {
+  beforeAll(() => {
+    HTMLDialogElement.prototype.showModal = vi.defineHelper(function (
+      this: HTMLDialogElement,
+    ) {
+      this.open = true;
+    });
+    HTMLDialogElement.prototype.close = vi.fn(function (
+      this: HTMLDialogElement,
+    ) {
+      this.open = false;
+    });
+  });
+  beforeEach(() => vi.clearAllMocks());
+  it('renders the route and displays elements', async () => {
+    renderBottleIdRouteWithAuth();
+    const selectors = await getSelectors();
+    expect(selectors.pageTitle).toBeInTheDocument();
+    expect(selectors.status).toBeInTheDocument();
+    expect(selectors.price).toBeInTheDocument();
+    expect(selectors.writeReviewLink).toHaveAttribute('href', '/reviews/new');
+    expect(selectors.editBottleLink).toHaveAttribute(
+      'href',
+      '/bottles/12345/edit',
+    );
+    expect(selectors.deleteBottleButton).toBeInTheDocument();
+    expect(selectors.bottleImage).toHaveAttribute(
+      'src',
+      'https://bourbon-nook.s3.amazonaws.com/8d617ebd-1ccd-45e3-876f-13df82cfe8c3/e89ae702-cfbc-475b-8ba4-8c6b3d4cb1f7-wtmk%20beacon.webp',
+    );
+  });
+  it('allows deleting a bottle', async () => {
+    const { router } = renderBottleIdRouteWithAuth();
+    const { deleteBottleButton } = await getSelectors();
+    const user = userEvent.setup();
+    const mockedBottleInstance = vi.mocked(customBottlesInstance);
+
+    await user.click(deleteBottleButton);
+    expect(
+      await screen.findByText(/delete this bottle\?/i),
+    ).toBeInTheDocument();
+    const confirmButton = await screen.findByRole('button', {
+      name: /^delete$/i,
+    });
+    await user.click(confirmButton);
+
+    expect(mockedBottleInstance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'DELETE',
+        url: '/bottles/12345',
+      }),
+    );
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe('/bottles'),
+    );
+  });
+  it('cancels the delete flow when pressing cancel', async () => {
+    const { router } = renderBottleIdRouteWithAuth();
+    const { deleteBottleButton } = await getSelectors();
+    const user = userEvent.setup();
+    const mockedBottleInstance = vi.mocked(customBottlesInstance);
+
+    await user.click(deleteBottleButton);
+    expect(
+      await screen.findByText(/delete this bottle\?/i),
+    ).toBeInTheDocument();
+    const cancelButton = await screen.findByRole('button', {
+      name: /^cancel$/i,
+    });
+    await user.click(cancelButton);
+
+    expect(mockedBottleInstance).not.toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe('/bottles/12345'),
+    );
+  });
+  it('shows an error when delete fails', async () => {
+    renderBottleIdRouteWithAuth();
+    const { deleteBottleButton } = await getSelectors();
+    const user = userEvent.setup();
+    const mockedBottleInstance = vi.mocked(customBottlesInstance);
+
+    mockedBottleInstance.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: { data: { message: 'Could not delete bottle with ID 12345' } },
+    });
+
+    await user.click(deleteBottleButton);
+    await user.click(await screen.findByRole('button', { name: /^delete$/i }));
+
+    expect(await screen.getByRole('alert')).toHaveTextContent(
+      /could not delete bottle with id 12345/i,
+    );
+  });
+  it('shows the missing image fallback when imageURL is undefined', async () => {
+    const mockedBottleInstance = vi.mocked(customBottlesInstance);
+
+    mockedBottleInstance.mockResolvedValue({
+      ...returnBottleResponse(),
+      imageUrl: undefined,
+    });
+
+    renderBottleIdRouteWithAuth();
+    const { bottleImage } = await getSelectors();
+
+    expect(bottleImage).toHaveAttribute(
+      'src',
+      '/src/assets/brand/png/bottle-cancel-1024.png',
+    );
+  });
+  it('shows detail component fallback when data is undefined', async () => {
+    const mockedBottleInstance = vi.mocked(customBottlesInstance);
+
+    mockedBottleInstance.mockResolvedValue({
+      ...returnBottleResponse(),
+      openDate: undefined,
+    });
+
+    renderBottleIdRouteWithAuth();
+    const openDate = await screen.findByText(/open date/i);
+
+    expect(openDate.nextElementSibling).toHaveTextContent('—');
+  });
+});

--- a/frontend/src/test/routes/bottles/edit.test.tsx
+++ b/frontend/src/test/routes/bottles/edit.test.tsx
@@ -1,0 +1,215 @@
+import { describe, it, expect } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import {
+  createMockAuthState,
+  renderWithFileRoutes,
+} from '../../file-route-utils';
+import userEvent from '@testing-library/user-event';
+import type { BottleResponseModel } from '../../../api/generated/bottles-api';
+import { customBottlesInstance } from '../../../api/axios-instance';
+
+function renderEditBottleRouteWithAuth() {
+  return renderWithFileRoutes({
+    initialLocation: '/bottles/12345/edit',
+    routerContext: {
+      auth: createMockAuthState({
+        user: {
+          id: '123abc',
+          email: 'test@email.com',
+          username: 'testuser',
+          roles: ['ROLE_USER'],
+        },
+        isAuthenticated: true,
+      }),
+    },
+  });
+}
+
+async function getSelectors() {
+  const bottleNameInput = await screen.findByRole('textbox', {
+    name: /bottle name/i,
+  });
+  const typeInput = await screen.findByRole('textbox', { name: /type/i });
+  const statusInput = await screen.findByLabelText(/bottle status/i);
+  const distilleryInput = await screen.findByRole('textbox', {
+    name: /distillery/i,
+  });
+  const producerInput = await screen.findByRole('textbox', {
+    name: /producer/i,
+  });
+  const countryInput = await screen.findByRole('textbox', {
+    name: /country of origin/i,
+  });
+  const regionInput = await screen.findByRole('textbox', { name: /region/i });
+  const priceInput = await screen.findByRole('spinbutton', {
+    name: /price/i,
+  });
+  const ageInput = await screen.findByRole('textbox', { name: /^age/i });
+  const proofInput = await screen.findByRole('spinbutton', {
+    name: /proof/i,
+  });
+  const yearInput = await screen.findByRole('spinbutton', {
+    name: /release year/i,
+  });
+  const barrelInput = await screen.findByRole('textbox', {
+    name: /barrel information/i,
+  });
+  const finishingInput = await screen.findByRole('textbox', {
+    name: /finishing barrels/i,
+  });
+  const openDateInput = await screen.findByLabelText(/open date/i);
+  const killDateInput = await screen.findByLabelText(/kill date/i);
+
+  const submitButton = await screen.findByRole('button', {
+    name: /save bottle/i,
+  });
+
+  return {
+    bottleNameInput,
+    typeInput,
+    statusInput,
+    distilleryInput,
+    producerInput,
+    countryInput,
+    regionInput,
+    priceInput,
+    ageInput,
+    proofInput,
+    yearInput,
+    barrelInput,
+    finishingInput,
+    openDateInput,
+    killDateInput,
+    submitButton,
+  };
+}
+
+function returnBottleResponse(): BottleResponseModel {
+  return {
+    name: 'Test bottle',
+    type: 'Bourbon',
+    status: 'SEALED',
+    distillery: 'Test distillery',
+    producer: 'Test producer',
+    country: 'Test country',
+    region: 'Test region',
+    price: 25.99,
+    age: 'NAS',
+    proof: 100,
+    releaseYear: 2025,
+    barrelInformation: 'N/A',
+    finishing: 'N/A',
+    imageUrl: '',
+    openDate: undefined,
+    killDate: undefined,
+  };
+}
+
+vi.mock('../../../api/axios-instance', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../api/axios-instance')>();
+  const bottleResponse = returnBottleResponse();
+
+  return {
+    ...actual,
+    customBottlesInstance: vi
+      .fn()
+      .mockResolvedValue({ id: '12345', ...bottleResponse }),
+  };
+});
+
+describe('Edit bottle route', () => {
+  beforeEach(() => vi.clearAllMocks());
+  it('shows the form elements with default values', async () => {
+    renderEditBottleRouteWithAuth();
+    const selectors = await getSelectors();
+
+    expect(selectors.bottleNameInput).toHaveValue('Test bottle');
+    expect(selectors.typeInput).toHaveValue('Bourbon');
+    expect(selectors.statusInput).toHaveValue('SEALED');
+    expect(selectors.distilleryInput).toHaveValue('Test distillery');
+    expect(selectors.producerInput).toHaveValue('Test producer');
+    expect(selectors.countryInput).toHaveValue('Test country');
+    expect(selectors.regionInput).toHaveValue('Test region');
+    expect(selectors.priceInput).toHaveValue(25.99);
+    expect(selectors.ageInput).toHaveValue('NAS');
+    expect(selectors.proofInput).toHaveValue(100);
+    expect(selectors.yearInput).toHaveValue(2025);
+    expect(selectors.barrelInput).toHaveValue('N/A');
+    expect(selectors.finishingInput).toHaveValue('N/A');
+  });
+  it('allows editing fields and submitting the form', async () => {
+    const { router } = renderEditBottleRouteWithAuth();
+    const selectors = await getSelectors();
+    const user = userEvent.setup();
+    const mockedCustomBottlesInstance = vi.mocked(customBottlesInstance);
+
+    await user.clear(selectors.bottleNameInput);
+    await user.type(selectors.bottleNameInput, 'New bottle');
+
+    await user.clear(selectors.typeInput);
+    await user.type(selectors.typeInput, 'Rye');
+
+    await user.selectOptions(selectors.statusInput, 'OPENED');
+
+    await user.clear(selectors.priceInput);
+    await user.type(selectors.priceInput, '100.00');
+
+    await waitFor(() => expect(selectors.submitButton).not.toBeDisabled(), {
+      timeout: 2000,
+    });
+    await user.click(selectors.submitButton);
+
+    expect(mockedCustomBottlesInstance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'PUT',
+        url: '/bottles/12345',
+        data: {
+          ...returnBottleResponse(),
+          name: 'New bottle',
+          type: 'Rye',
+          status: 'OPENED',
+          price: 100.0,
+        },
+      }),
+    );
+
+    expect(router.state.location.pathname).toBe('/bottles/12345');
+    expect(await screen.findByText(/add photo/i)).toBeInTheDocument();
+  });
+  it('shows the backend error message on a failed edit', async () => {
+    renderEditBottleRouteWithAuth();
+    const { submitButton } = await getSelectors();
+    const user = userEvent.setup();
+    const mockedCustomBottlesInstance = vi.mocked(customBottlesInstance);
+
+    mockedCustomBottlesInstance.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: { data: { message: 'Could not save your edits' } },
+    });
+
+    await waitFor(() => expect(submitButton).not.toBeDisabled());
+    await user.click(submitButton);
+
+    expect(await screen.getByRole('alert')).toHaveTextContent(
+      /could not save your edits/i,
+    );
+  });
+  it('shows client-side validation', async () => {
+    renderEditBottleRouteWithAuth();
+    const user = userEvent.setup();
+    const selectors = await getSelectors();
+
+    await user.clear(selectors.bottleNameInput);
+    await user.tab();
+    expect(await screen.getByRole('alert')).toHaveTextContent(
+      'Name is required',
+    );
+
+    await user.type(selectors.bottleNameInput, 'George Remus');
+    await user.tab();
+    await waitFor(() =>
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument(),
+    );
+  });
+});

--- a/frontend/src/test/routes/bottles/index.test.tsx
+++ b/frontend/src/test/routes/bottles/index.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import {
+  createMockAuthState,
+  renderWithFileRoutes,
+} from '../../file-route-utils';
+import {
+  useUserBottlesSuspense,
+  type BottleResponseModel,
+} from '../../../api/generated/bottles-api';
+
+const mockBottles: BottleResponseModel[] = [
+  {
+    name: 'Mock Bottle',
+    type: 'Bourbon',
+    status: 'OPENED',
+    distillery: 'Mock Distillery',
+    producer: 'Mock Producer',
+    country: 'USA',
+    region: 'KY',
+    price: 25.99,
+    age: 'NAS',
+    proof: 115.2,
+    releaseYear: 2026,
+    barrelInformation: 'N/A',
+    finishing: 'N/A',
+    imageUrl: 'N/A',
+    openDate: '2026-07-29',
+    killDate: undefined,
+  },
+];
+
+vi.mock('../../../api/generated/bottles-api', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../api/generated/bottles-api')>();
+  return {
+    ...actual,
+    getUserBottlesQueryOptions: () => ({
+      queryKey: actual.getUserBottlesQueryKey(),
+      queryFn: () => Promise.resolve([]),
+    }),
+    useUserBottlesSuspense: vi.fn(),
+  };
+});
+
+function renderBottlesRoute() {
+  return renderWithFileRoutes({
+    initialLocation: '/bottles',
+    routerContext: {
+      auth: createMockAuthState({
+        user: {
+          id: '123abc',
+          email: 'test@email.com',
+          username: 'testuser',
+          roles: ['ROLE_USER'],
+        },
+        isAuthenticated: true,
+      }),
+    },
+  });
+}
+
+describe('Bottle index route', () => {
+  it('shows the empty state when there are no bottles', async () => {
+    vi.mocked(useUserBottlesSuspense).mockReturnValue({
+      data: [],
+    } as ReturnType<typeof useUserBottlesSuspense>);
+
+    renderBottlesRoute();
+
+    expect(await screen.findByText(/your collection/i)).toBeInTheDocument();
+    expect(await screen.findByText(/no bottles yet\./i)).toBeInTheDocument();
+    expect(
+      await screen.findByRole('link', { name: /add one/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows bottles when the collection has data', async () => {
+    vi.mocked(useUserBottlesSuspense).mockReturnValue({
+      data: mockBottles,
+    } as ReturnType<typeof useUserBottlesSuspense>);
+
+    renderBottlesRoute();
+
+    expect(await screen.findByText(/your collection/i)).toBeInTheDocument();
+    expect(await screen.findByText('Mock Bottle')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('link', { name: /edit bottle/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/no bottles yet\./i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/routes/bottles/new.test.tsx
+++ b/frontend/src/test/routes/bottles/new.test.tsx
@@ -1,0 +1,238 @@
+import { describe, it, expect } from 'vitest';
+import { screen, waitFor, within } from '@testing-library/react';
+import {
+  createMockAuthState,
+  renderWithFileRoutes,
+} from '../../file-route-utils';
+import userEvent from '@testing-library/user-event';
+import type { BottleResponseModel } from '../../../api/generated/bottles-api';
+import { customBottlesInstance } from '../../../api/axios-instance';
+
+function renderNewBottleRouteWithAuth() {
+  return renderWithFileRoutes({
+    initialLocation: '/bottles/new',
+    routerContext: {
+      auth: createMockAuthState({
+        user: {
+          id: '123abc',
+          email: 'test@email.com',
+          username: 'testuser',
+          roles: ['ROLE_USER'],
+        },
+        isAuthenticated: true,
+      }),
+    },
+  });
+}
+
+async function getSelectors() {
+  const bottleNameInput = await screen.findByRole('textbox', {
+    name: /bottle name/i,
+  });
+  const typeInput = await screen.findByRole('textbox', { name: /type/i });
+  const statusInput = await screen.findByLabelText(/bottle status/i);
+  const distilleryInput = await screen.findByRole('textbox', {
+    name: /distillery/i,
+  });
+  const producerInput = await screen.findByRole('textbox', {
+    name: /producer/i,
+  });
+  const countryInput = await screen.findByRole('textbox', {
+    name: /country of origin/i,
+  });
+  const regionInput = await screen.findByRole('textbox', { name: /region/i });
+  const priceInput = await screen.findByRole('spinbutton', {
+    name: /price/i,
+  });
+  const ageInput = await screen.findByRole('textbox', { name: /^age/i });
+  const proofInput = await screen.findByRole('spinbutton', {
+    name: /proof/i,
+  });
+  const yearInput = await screen.findByRole('spinbutton', {
+    name: /release year/i,
+  });
+  const barrelInput = await screen.findByRole('textbox', {
+    name: /barrel information/i,
+  });
+  const finishingInput = await screen.findByRole('textbox', {
+    name: /finishing barrels/i,
+  });
+  const openDateInput = await screen.findByLabelText(/open date/i);
+  const killDateInput = await screen.findByLabelText(/kill date/i);
+
+  const submitButton = await screen.findByRole('button', {
+    name: /save bottle/i,
+  });
+
+  return {
+    bottleNameInput,
+    typeInput,
+    statusInput,
+    distilleryInput,
+    producerInput,
+    countryInput,
+    regionInput,
+    priceInput,
+    ageInput,
+    proofInput,
+    yearInput,
+    barrelInput,
+    finishingInput,
+    openDateInput,
+    killDateInput,
+    submitButton,
+  };
+}
+
+function returnBottleResponse(): BottleResponseModel {
+  return {
+    name: 'Test bottle',
+    type: 'Bourbon',
+    status: 'SEALED',
+    distillery: 'Test distillery',
+    producer: 'Test producer',
+    country: 'Test country',
+    region: 'Test region',
+    price: 25.99,
+    age: 'NAS',
+    proof: 100,
+    releaseYear: 2025,
+    barrelInformation: 'N/A',
+    finishing: 'N/A',
+    imageUrl: '',
+    openDate: undefined,
+    killDate: undefined,
+  };
+}
+
+vi.mock('../../../api/axios-instance', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../api/axios-instance')>();
+  const bottleResponse = returnBottleResponse();
+
+  return {
+    ...actual,
+    customBottlesInstance: vi
+      .fn()
+      .mockResolvedValue({ id: '12345', ...bottleResponse }),
+  };
+});
+
+describe('New bottle route', () => {
+  beforeEach(() => vi.clearAllMocks());
+  it('shows the form elements', async () => {
+    renderNewBottleRouteWithAuth();
+    const selectors = await getSelectors();
+
+    expect(selectors.bottleNameInput).toBeInTheDocument();
+    expect(selectors.typeInput).toBeInTheDocument();
+    expect(selectors.statusInput).toBeInTheDocument();
+    expect(selectors.distilleryInput).toBeInTheDocument();
+    expect(selectors.producerInput).toBeInTheDocument();
+    expect(selectors.countryInput).toBeInTheDocument();
+    expect(selectors.regionInput).toBeInTheDocument();
+    expect(selectors.priceInput).toBeInTheDocument();
+    expect(selectors.ageInput).toBeInTheDocument();
+    expect(selectors.proofInput).toBeInTheDocument();
+    expect(selectors.yearInput).toBeInTheDocument();
+    expect(selectors.barrelInput).toBeInTheDocument();
+    expect(selectors.finishingInput).toBeInTheDocument();
+    expect(selectors.openDateInput).toBeInTheDocument();
+    expect(selectors.killDateInput).toBeInTheDocument();
+    expect(selectors.submitButton).toBeInTheDocument();
+  });
+  it('allows submitting the form', async () => {
+    renderNewBottleRouteWithAuth();
+    const selectors = await getSelectors();
+    const user = userEvent.setup();
+    const mockedCustomBottlesInstance = vi.mocked(customBottlesInstance);
+
+    await user.type(selectors.bottleNameInput, 'Test bottle');
+    await user.type(selectors.typeInput, 'Bourbon');
+    await user.type(selectors.distilleryInput, 'Test distillery');
+    await user.type(selectors.producerInput, 'Test producer');
+    await user.type(selectors.countryInput, 'Test country');
+    await user.type(selectors.regionInput, 'Test region');
+    await user.type(selectors.priceInput, '25.99');
+    await user.type(selectors.ageInput, 'NAS');
+    await user.type(selectors.proofInput, '100');
+    await user.type(selectors.yearInput, '2025');
+    await user.type(selectors.barrelInput, 'N/A');
+    await user.type(selectors.finishingInput, 'N/A');
+    await waitFor(() => expect(selectors.submitButton).not.toBeDisabled(), {
+      timeout: 2000,
+    });
+    await user.click(selectors.submitButton);
+
+    expect(mockedCustomBottlesInstance).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        method: 'POST',
+        url: '/bottles/new',
+        data: { ...returnBottleResponse() },
+      }),
+    );
+
+    expect(mockedCustomBottlesInstance).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ method: 'GET', url: '/bottles/12345' }),
+    );
+
+    expect(await screen.findByText(/test bottle/i)).toBeInTheDocument();
+    expect(await screen.findByText(/add photo/i)).toBeInTheDocument();
+  });
+  it('redirects unauthenticated users to /login', async () => {
+    renderWithFileRoutes({
+      initialLocation: '/bottles/new',
+      routerContext: {
+        auth: createMockAuthState({
+          user: null,
+          isAuthenticated: false,
+        }),
+      },
+    });
+
+    expect(
+      await screen.findByText(/log in to bourbonnook/i),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole('textbox', { name: /email/i }),
+    ).toBeInTheDocument();
+  });
+  it('shows the backend error message on a failed create', async () => {
+    renderNewBottleRouteWithAuth();
+    const { bottleNameInput, typeInput, submitButton } = await getSelectors();
+    const user = userEvent.setup();
+    const mockedCustomBottlesInstance = vi.mocked(customBottlesInstance);
+
+    mockedCustomBottlesInstance.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: { data: { message: 'Could not save bottle: connection lost' } },
+    });
+
+    await user.type(bottleNameInput, 'Test');
+    await user.type(typeInput, 'Bourbon');
+    await user.tab();
+    await waitFor(() => expect(submitButton).not.toBeDisabled());
+    await user.click(submitButton);
+
+    expect(await screen.getByRole('alert')).toHaveTextContent(
+      /could not save bottle: connection lost/i,
+    );
+  });
+  it('shows client side validation', async () => {
+    renderNewBottleRouteWithAuth();
+    const selectors = await getSelectors();
+    const user = userEvent.setup();
+
+    await user.click(selectors.submitButton);
+
+    expect(
+      within(selectors.bottleNameInput.closest('div')!).getByRole('alert'),
+    ).toHaveTextContent(/name is required/i);
+
+    expect(
+      within(selectors.typeInput.closest('div')!).getByRole('alert'),
+    ).toHaveTextContent(/type is required/i);
+  });
+});


### PR DESCRIPTION
# Add tests for `/bottles` routes

## What did you do?
- Added tests for `/bottles`, `/bottles/new`, `/bottles/$bottleId`, and `/bottles/$bottleId/edit` routes
- Make small tweaks to API and forms to support these tests