### PR TITLE
chore: add tests for admin screens

### DIFF
--- a/frontend/src/components/Tables/UserActions.tsx
+++ b/frontend/src/components/Tables/UserActions.tsx
@@ -30,8 +30,13 @@ export default function UserActions({ userId, onDeleted }: UserActionProps) {
   });
   return (
     <div className="flex justify-evenly mx-4">
-      <div title="Edit User">
-        <Link to="/admin/users/$userId/edit" params={{ userId }}>
+      <div>
+        <Link
+          to="/admin/users/$userId/edit"
+          params={{ userId }}
+          title="Edit User"
+          aria-label="Edit User"
+        >
           <EditIcon />
         </Link>
       </div>

--- a/frontend/src/components/Tables/shared/TFootRow.tsx
+++ b/frontend/src/components/Tables/shared/TFootRow.tsx
@@ -11,7 +11,7 @@ export default function TFootRow({ table, headerGroup }: TFootRowProps) {
     <tr key={headerGroup.id}>
       {headerGroup.headers.map((header) =>
         header.rowSpan === 0 || header.colSpan === 0 ? null : (
-          <TFootCell table={table} header={header} />
+          <TFootCell key={header.id} table={table} header={header} />
         ),
       )}
     </tr>

--- a/frontend/src/routes/_authenticated/admin.tsx
+++ b/frontend/src/routes/_authenticated/admin.tsx
@@ -2,7 +2,7 @@ import { createFileRoute, Outlet, redirect } from '@tanstack/react-router';
 
 export const Route = createFileRoute('/_authenticated/admin')({
   beforeLoad: ({ context, location }) => {
-    if (!context.auth.hasAnyRole(['ROLE_ADMIN'])) {
+    if (!context.auth.hasRole('ROLE_ADMIN')) {
       throw redirect({
         to: '/unauthorized',
         search: {

--- a/frontend/src/test/routes/admin/dashboard.test.tsx
+++ b/frontend/src/test/routes/admin/dashboard.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi } from 'vite-plus/test';
+import { screen, within } from '@testing-library/react';
+import { createMockAuthState, renderWithFileRoutes } from '../../file-route-utils';
+
+describe('Admin dashboard route', () => {
+  it('renders the dashboard components', async () => {
+    renderWithFileRoutes({
+      initialLocation: '/admin/dashboard',
+      routerContext: {
+        auth: createMockAuthState({
+          user: {
+            id: '123abc',
+            email: 'test@user.com',
+            username: 'testuser',
+            roles: ['ROLE_ADMIN', 'ROLE_USER'],
+          },
+          isAuthenticated: true,
+          hasRole: vi.fn((role: string) => ['ROLE_ADMIN', 'ROLE_USER'].includes(role)),
+        }),
+      },
+    });
+    expect(await screen.findByText(/admin area/i)).toBeInTheDocument();
+    expect(
+      await screen.findByRole('heading', { level: 1, name: /dashboard/i }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole('heading', { level: 2, name: /user management/i }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole('heading', { level: 2, name: /system settings/i }),
+    ).toBeInTheDocument();
+    expect(await screen.findByRole('link', { name: /view users/i })).toHaveAttribute(
+      'href',
+      '/admin/users',
+    );
+    expect(await screen.findByRole('link', { name: /open settings/i })).toHaveAttribute(
+      'href',
+      '/admin/system-settings',
+    );
+    const userInfoHeader = (await screen.findByRole('heading', { level: 3, name: /your info/i }))
+      .parentElement;
+    expect(userInfoHeader).toBeInTheDocument();
+    const userInfoParagraphs = await within(userInfoHeader!).findAllByRole('paragraph');
+
+    expect(userInfoParagraphs[0]).toHaveTextContent(/username: testuser/i);
+    expect(userInfoParagraphs[1]).toHaveTextContent(/roles: ROLE_ADMIN, ROLE_USER/i);
+  });
+  it('directs to the unauthorized route if the user is not an admin', async () => {
+    const { router } = renderWithFileRoutes({
+      initialLocation: '/admin/dashboard',
+      routerContext: {
+        auth: createMockAuthState({
+          user: {
+            id: '123abc',
+            email: 'test@user.com',
+            username: 'testuser',
+            roles: ['ROLE_USER'],
+          },
+          isAuthenticated: true,
+          hasRole: vi.fn((role: string) => ['ROLE_USER'].includes(role)),
+        }),
+      },
+    });
+    expect(
+      await screen.findByRole('heading', { level: 1, name: /access denied/i }),
+    ).toBeInTheDocument();
+    expect(await screen.findByText(/role_user/i)).toBeInTheDocument();
+    expect(await screen.findByRole('link', { name: /go to dashboard/i })).toBeInTheDocument();
+    expect(await screen.findByRole('link', { name: /try again/i })).toBeInTheDocument();
+    expect(router.state.location.pathname).toBe('/unauthorized');
+    expect(router.state.location.search.reason).toBe('insufficient_role');
+  });
+  it('ensures user with just admin rights can access', async () => {
+    const { router } = renderWithFileRoutes({
+      initialLocation: '/admin/dashboard',
+      routerContext: {
+        auth: createMockAuthState({
+          user: {
+            id: '123abc',
+            email: 'test@user.com',
+            username: 'testuser',
+            roles: ['ROLE_ADMIN'],
+          },
+          isAuthenticated: true,
+          hasRole: vi.fn((role: string) => ['ROLE_ADMIN'].includes(role)),
+        }),
+      },
+    });
+    expect(await screen.findByText(/admin area/i)).toBeInTheDocument();
+    expect(
+      await screen.findByRole('heading', { level: 1, name: /dashboard/i }),
+    ).toBeInTheDocument();
+    expect(router.state.location.pathname).toBe('/admin/dashboard');
+  });
+  it('redirects when the user is not authenticated', async () => {
+    const { router } = renderWithFileRoutes({
+      initialLocation: '/admin/dashboard',
+      routerContext: {
+        auth: createMockAuthState({
+          user: null,
+          isAuthenticated: false,
+        }),
+      },
+    });
+    expect(
+      await screen.findByRole('heading', { level: 1, name: /log in to bourbonnook/i }),
+    ).toBeInTheDocument();
+    expect(router.state.location.pathname).toBe('/login');
+    expect(router.state.location.search).toEqual({
+      redirect: '/admin/dashboard',
+    });
+  });
+});

--- a/frontend/src/test/routes/admin/user-edit.test.tsx
+++ b/frontend/src/test/routes/admin/user-edit.test.tsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { screen } from '@testing-library/react';
+import { createMockAuthState, renderWithFileRoutes } from '../../file-route-utils';
+import {
+  getGetUserQueryKey,
+  updateUser,
+  useGetUserSuspense,
+  type UserResponseModel,
+} from '../../../api/generated/users-api';
+import userEvent from '@testing-library/user-event';
+
+const mockUser: UserResponseModel = {
+  userId: '456efj',
+  email: 'newuser@gmail.com',
+  username: 'myusername',
+  roles: ['ROLE_USER'],
+};
+
+function renderAdminUsersPageWithAuth() {
+  return renderWithFileRoutes({
+    initialLocation: '/admin/users/456efj/edit',
+    routerContext: {
+      auth: createMockAuthState({
+        user: {
+          id: '123abc',
+          email: 'test@user.com',
+          username: 'testuser',
+          roles: ['ROLE_ADMIN', 'ROLE_USER'],
+        },
+        isAuthenticated: true,
+        hasRole: vi.fn((role: string) => ['ROLE_ADMIN', 'ROLE_USER'].includes(role)),
+      }),
+    },
+  });
+}
+
+vi.mock('../../../api/generated/users-api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../api/generated/users-api')>();
+
+  return {
+    ...actual,
+    getGetUserQueryOptions: () => ({
+      queryKey: getGetUserQueryKey('456efj'),
+      queryFn: () => Promise.resolve(mockUser),
+    }),
+    useGetUserSuspense: vi.fn(),
+    updateUser: vi.fn(),
+  };
+});
+
+describe('Edit user route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useGetUserSuspense).mockReturnValue({
+      data: mockUser,
+    } as ReturnType<typeof useGetUserSuspense>);
+  });
+  it('renders the form components correctly', async () => {
+    renderAdminUsersPageWithAuth();
+
+    const emailInput = await screen.findByRole('textbox', { name: /email/i });
+    const usernameInput = await screen.findByRole('textbox', { name: /username/i });
+    expect(await screen.findByRole('heading', { level: 1 })).toHaveTextContent('Edit User 456efj');
+    expect(emailInput).toBeInTheDocument();
+    expect(emailInput).toHaveValue('newuser@gmail.com');
+    expect(usernameInput).toBeInTheDocument();
+    expect(usernameInput).toHaveValue('myusername');
+    expect(await screen.findByRole('button', { name: /update user/i })).toBeInTheDocument();
+    expect(await screen.findByRole('link', { name: /back to users/i })).toHaveAttribute(
+      'href',
+      '/admin/users',
+    );
+  });
+  it('handles interacting with the form and form submission', async () => {
+    const { router } = renderAdminUsersPageWithAuth();
+    const user = userEvent.setup();
+    vi.mocked(updateUser).mockReturnValueOnce({} as ReturnType<typeof updateUser>);
+
+    const emailInput = await screen.findByRole('textbox', { name: /email/i });
+    const usernameInput = await screen.findByRole('textbox', { name: /username/i });
+
+    await user.clear(emailInput);
+    await user.type(emailInput, 'mynewemail@gmail.com');
+    expect(emailInput).toHaveValue('mynewemail@gmail.com');
+
+    await user.clear(usernameInput);
+    await user.type(usernameInput, 'flyguy50');
+    expect(usernameInput).toHaveValue('flyguy50');
+
+    await user.click(await screen.findByRole('button', { name: /update user/i }));
+
+    expect(updateUser).toHaveBeenCalledWith('456efj', {
+      email: 'mynewemail@gmail.com',
+      username: 'flyguy50',
+    });
+    expect(router.state.location.pathname).toBe('/admin/users');
+  });
+  it('handles server error when updateUser fails', async () => {
+    const { router } = renderAdminUsersPageWithAuth();
+    vi.mocked(updateUser).mockRejectedValueOnce({
+      isAxiosError: true,
+      response: { data: { message: 'Email already in use' } },
+    });
+    const user = userEvent.setup();
+
+    await user.click(await screen.findByRole('button', { name: /update user/i }));
+    expect(await screen.findByRole('alert')).toHaveTextContent(/email already in use/i);
+    expect(router.state.location.pathname).toBe('/admin/users/456efj/edit');
+  });
+  it('handles client-side validation', async () => {
+    renderAdminUsersPageWithAuth();
+    const user = userEvent.setup();
+
+    const emailInput = await screen.findByRole('textbox', { name: /email/i });
+    const usernameInput = await screen.findByRole('textbox', { name: /username/i });
+
+    await user.clear(emailInput);
+    await user.tab();
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      /please enter a valid email address/i,
+    );
+    await user.type(emailInput, 'myemail@gmail.com');
+    await user.tab();
+    expect(await screen.queryByRole('alert')).toBeNull();
+
+    await user.clear(usernameInput);
+    await user.tab();
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      /username must be at least 3 characters/i,
+    );
+
+    await user.type(usernameInput, 'mynewusername');
+    await user.tab();
+    expect(await screen.queryByRole('alert')).toBeNull();
+  });
+  it('redirects to /unauthorized if the user is not an admin', async () => {
+    const { router } = renderWithFileRoutes({
+      initialLocation: '/admin/users/456efj/edit',
+      routerContext: {
+        auth: createMockAuthState({
+          user: {
+            id: '123abc',
+            email: 'test@user.com',
+            username: 'testuser',
+            roles: ['ROLE_USER'],
+          },
+          isAuthenticated: true,
+          hasRole: vi.fn((role: string) => ['ROLE_USER'].includes(role)),
+        }),
+      },
+    });
+
+    expect(
+      await screen.findByRole('heading', { level: 1, name: /access denied/i }),
+    ).toBeInTheDocument();
+    expect(router.state.location.pathname).toBe('/unauthorized');
+    expect(router.state.location.search.reason).toBe('insufficient_role');
+  });
+  it('redirects to /login if the user is not authenticated', async () => {
+    const { router } = renderWithFileRoutes({
+      initialLocation: '/admin/users/456efj/edit',
+      routerContext: {
+        auth: createMockAuthState({
+          user: {
+            id: '123abc',
+            email: 'test@user.com',
+            username: 'testuser',
+            roles: ['ROLE_USER'],
+          },
+          isAuthenticated: false,
+          hasRole: vi.fn((role: string) => ['ROLE_USER'].includes(role)),
+        }),
+      },
+    });
+
+    expect(
+      await screen.findByRole('heading', { level: 1, name: /log in to bourbonnook/i }),
+    ).toBeInTheDocument();
+    expect(router.state.location.pathname).toBe('/login');
+    expect(router.state.location.search).toEqual({ redirect: '/admin/users/456efj/edit' });
+  });
+});

--- a/frontend/src/test/routes/admin/users.test.tsx
+++ b/frontend/src/test/routes/admin/users.test.tsx
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { screen, within } from '@testing-library/react';
+import { createMockAuthState, renderWithFileRoutes } from '../../file-route-utils';
+import {
+  getGetUsersQueryKey,
+  useDeleteUser,
+  useGetUsersSuspense,
+  type UserResponseModel,
+} from '../../../api/generated/users-api';
+import userEvent from '@testing-library/user-event';
+
+const mockUsers: UserResponseModel[] = [
+  {
+    userId: '123abc',
+    email: 'test@user.com',
+    username: 'testuser',
+    roles: ['ROLE_USER'],
+  },
+  {
+    userId: '456efg',
+    email: 'test2@user.com',
+    username: 'newuser',
+    roles: ['ROLE_ADMIN', 'ROLE_USER'],
+  },
+];
+
+function renderAdminUsersPageWithAuth() {
+  return renderWithFileRoutes({
+    initialLocation: '/admin/users',
+    routerContext: {
+      auth: createMockAuthState({
+        user: {
+          id: '123abc',
+          email: 'test@user.com',
+          username: 'testuser',
+          roles: ['ROLE_ADMIN', 'ROLE_USER'],
+        },
+        isAuthenticated: true,
+        hasRole: vi.fn((role: string) => ['ROLE_ADMIN', 'ROLE_USER'].includes(role)),
+      }),
+    },
+  });
+}
+
+vi.mock('../../../api/generated/users-api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../api/generated/users-api')>();
+
+  return {
+    ...actual,
+    getGetUsersQueryOptions: () => ({
+      queryKey: getGetUsersQueryKey(),
+      queryFn: () => Promise.resolve(mockUsers),
+    }),
+    useGetUsersSuspense: vi.fn(),
+    useDeleteUser: vi.fn(),
+  };
+});
+
+describe('Admin users route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useGetUsersSuspense).mockReturnValue({
+      data: mockUsers,
+    } as ReturnType<typeof useGetUsersSuspense>);
+    vi.mocked(useDeleteUser).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      error: null,
+    } as unknown as ReturnType<typeof useDeleteUser>);
+  });
+  it('renders the users route with table, headings, and links', async () => {
+    renderAdminUsersPageWithAuth();
+    expect(await screen.findByRole('heading', { level: 1, name: /users/i })).toBeInTheDocument();
+    expect(await screen.findByRole('link', { name: /← back to admin dashboard/i })).toHaveAttribute(
+      'href',
+      '/admin/dashboard',
+    );
+    expect(await screen.findByRole('table')).toBeInTheDocument();
+    expect(await screen.findByText('test@user.com')).toBeInTheDocument();
+    const row = (await screen.findByText('test@user.com')).closest('tr');
+    const editLink = within(row!).getByRole('link', { name: /edit user/i });
+    expect(editLink).toHaveAttribute('href', '/admin/users/123abc/edit');
+  });
+  it('renders an empty table if there are no users', async () => {
+    vi.mocked(useGetUsersSuspense).mockReturnValueOnce({
+      data: [],
+    } as ReturnType<typeof useGetUsersSuspense>);
+    renderAdminUsersPageWithAuth();
+    expect(await screen.findByText(/no users/i)).toBeInTheDocument();
+  });
+  it('redirects to the /unauthorized route if the user is not an admin', async () => {
+    const { router } = renderWithFileRoutes({
+      initialLocation: '/admin/users',
+      routerContext: {
+        auth: createMockAuthState({
+          user: {
+            id: '123abc',
+            email: 'test@user.com',
+            username: 'testuser',
+            roles: ['ROLE_USER'],
+          },
+          isAuthenticated: true,
+          hasRole: (role: string) => ['ROLE_USER'].includes(role),
+        }),
+      },
+    });
+    expect(
+      await screen.findByRole('heading', { level: 1, name: /access denied/i }),
+    ).toBeInTheDocument();
+    expect(router.state.location.pathname).toBe('/unauthorized');
+    expect(router.state.location.search.reason).toBe('insufficient_role');
+  });
+  it('redirects to /login if the user is not authenticated', async () => {
+    const { router } = renderWithFileRoutes({
+      initialLocation: '/admin/users',
+      routerContext: {
+        auth: createMockAuthState({
+          user: {
+            id: '123abc',
+            email: 'test@user.com',
+            username: 'testuser',
+            roles: ['ROLE_USER'],
+          },
+          isAuthenticated: false,
+          hasRole: (role: string) => ['ROLE_USER'].includes(role),
+        }),
+      },
+    });
+    expect(
+      await screen.findByRole('heading', { level: 1, name: /log in to bourbonnook/i }),
+    ).toBeInTheDocument();
+    expect(router.state.location.pathname).toBe('/login');
+    expect(router.state.location.search).toEqual({ redirect: '/admin/users' });
+  });
+  it('handles the edit flow correctly', async () => {
+    const { router } = renderAdminUsersPageWithAuth();
+    const user = userEvent.setup();
+
+    const row = (await screen.findByText('test@user.com')).closest('tr');
+    const editLink = within(row!).getByRole('link', { name: /edit user/i });
+    await user.click(editLink);
+
+    expect(router.state.location.pathname).toBe('/admin/users/123abc/edit');
+  });
+  it('handles the delete user flow correctly', async () => {
+    renderAdminUsersPageWithAuth();
+    const user = userEvent.setup();
+    const mockDeleteMutate = vi.fn();
+    vi.mocked(useDeleteUser).mockReturnValue({
+      mutate: mockDeleteMutate,
+      isPending: false,
+      error: null,
+    } as unknown as ReturnType<typeof useDeleteUser>);
+
+    const row = (await screen.findByText('test@user.com')).closest('tr');
+    const deleteButton = within(row!).getByRole('button', { name: /delete user/i });
+    await user.click(deleteButton);
+
+    expect(await screen.findByRole('heading', { name: /delete this user\?/i })).toBeInTheDocument();
+
+    const cancelButton = await screen.findByRole('button', { name: /cancel/i });
+    expect(cancelButton).toBeInTheDocument();
+    await user.click(cancelButton);
+    expect(await screen.queryByRole('button', { name: /cancel/i })).toBeNull();
+    expect(mockDeleteMutate).not.toHaveBeenCalled();
+
+    await user.click(deleteButton);
+    const deleteButtons = await screen.findAllByRole('button', { name: /delete/i });
+    await user.click(deleteButtons[1]);
+    expect(mockDeleteMutate).toHaveBeenCalledTimes(1);
+    expect(mockDeleteMutate).toHaveBeenCalledWith({ id: '123abc' });
+  });
+});


### PR DESCRIPTION
# Tests for `/admin/*` screens

## What did you do?
- Add tests for `/admin/dashboard`, `/admin/users` and `/admin/users/$userId/edit`
- Made small changes to components to support tests